### PR TITLE
Revise database export instructions in Xampp guide

### DIFF
--- a/pages/General/Xampp.mdx
+++ b/pages/General/Xampp.mdx
@@ -36,7 +36,9 @@ First of all I will start off by addressing the most common issue that Xampp Con
 First of all it's very important to make a back-up of your database before we delete this pile of shit for once and for all from our PC's
 </Callout>
 
-1. Search on Google how to make an export of the SQL file from the database. This can vary per software you use to manage your database.
+1. Make an export of your Database:
+   - **Heidi:** https://support.appliedi.net/kb/how-to-import-and-export-a-mysql-database-using-heidisql/
+   - **PHPMyAdmin**: https://docs.phpmyadmin.net/en/latest/import_export.html
 2. Put the exported SQL file in a location that you can remember such as your `Desktop`
 3. Now that we have successfully made a back-up of our database, it's time to continue to the next part.
 


### PR DESCRIPTION
Updated instructions for exporting a database with specific software links cause why not.